### PR TITLE
fix: fix Data hijacking demo code in framework page

### DIFF
--- a/Framework/framework-en.md
+++ b/Framework/framework-en.md
@@ -58,8 +58,8 @@ function observe(obj) {
   if (!obj || typeof obj !== 'object') {
     return
   }
-  Object.keys(data).forEach(key => {
-    defineReactive(data, key, data[key])
+  Object.keys(obj).forEach(key => {
+    defineReactive(obj, key, obj[key])
   })
 }
 

--- a/Framework/framework-zh.md
+++ b/Framework/framework-zh.md
@@ -55,8 +55,8 @@ function observe(obj) {
   if (!obj || typeof obj !== 'object') {
     return
   }
-  Object.keys(data).forEach(key => {
-    defineReactive(data, key, data[key])
+  Object.keys(obj).forEach(key => {
+    defineReactive(obj, key, obj[key])
   })
 }
 


### PR DESCRIPTION
In data hijacking demo, observe function code

```js
Object.keys(data).forEach(key => {
    defineReactive(data, key, data[key])
  })
```

may not right , variable `data` may need to replaced by parameter `obj`. although, in this code parameter `obj` equal to variable `data`, but direct use of `data` may confuse, so in this code , use parameter `obj` may better.